### PR TITLE
Fixes for MW 1.36+

### DIFF
--- a/TalkRight.class.php
+++ b/TalkRight.class.php
@@ -32,7 +32,7 @@ class TalkRight {
      */    
     static function giveEditRightsWhenViewingTalkPages ( &$parser, &$test1, &$test2 ) {
         
-        $user = $parser->getUser();
+        $user = $parser->getUserIdentity();
         if ( $parser->getTitle()->isTalkPage() && $user->isAllowed( 'talk' ) ) {
             array_push( $user->mRights, 'edit' );            
         }

--- a/extension.json
+++ b/extension.json
@@ -19,7 +19,7 @@
 		"AlternateEdit": [
 			"TalkRight::alternateEdit"
 		],
-		"ParserBeforeStrip": [
+		"ParserBeforeInternalParse": [
 			"TalkRight::giveEditRightsWhenViewingTalkPages"
 		]
 	},


### PR DESCRIPTION
Corrects deprecated calls so that the extension works with MediaWiki 1.36+